### PR TITLE
Add a help screen that appears if zip option undefined or help option is present.

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ const usageDefinition = [
   }
 ]
 
+// if --help is present or --zip wasn't defined, 
+// then display the help screen and exit the program.
 if (options['help'] || options['zip'] === undefined) {
   console.log(getUsage(usageDefinition));
   process.exit();

--- a/index.js
+++ b/index.js
@@ -1,22 +1,58 @@
 // Require npm packages.
 const fetch = require('node-fetch');
 const commandLineArgs = require('command-line-args');
+const getUsage = require('command-line-usage');
 
 // Get partNumbers from json file.
 const partNumbers = require('./partNumbers.json');
 
 // Define command line args accepted.
 const optionDefinitions = [
-  { name: 'carrier', type: String, defaultValue: 'TMOBILE' },
-  { name: 'model', type: String, defaultValue: 'x' },
-  { name: 'color', type: String, defaultValue: 'gray' },
-  { name: 'storage', type: String, defaultValue: '256' },
-  { name: 'zip', type: String, defaultOption: true },
-  { name: 'delay', type: Number, defaultValue: 30 },
+  { name: 'carrier', type: String, defaultValue: 'TMOBILE', description: "Define which carrier to search for.  Accepted options are: 'ATT', 'SPRING', 'TMOBILE', 'VERIZON'."},
+  { name: 'model', type: String, defaultValue: 'x', description: "Define which model iPhone to search for.  'x' is the only option currently available."},
+  { name: 'color', type: String, defaultValue: 'gray', description: "Define which color iPhone to search for.  Accepted options are: 'silver', 'gray'."},
+  { name: 'storage', type: String, defaultValue: '256', description: "Define which storage size to search for.  Accepted options are: '64', '256'."},
+  { name: 'zip', type: String, defaultOption: true, description: "Define the area to search in by zip code.  This option is required."},
+  { name: 'delay', type: Number, defaultValue: 30, description: "Define the number of seconds between requests."},
+  { name: 'help', type: Boolean, description: "Display this help screen."},
 ];
 
 // Parse command line args.
 const options = commandLineArgs(optionDefinitions);
+
+// Define the help screen to be displayed if --help is present in options
+const usageDefinition = [
+  {
+    header: 'iPhone X Availability Node CLI',
+    content: "The app continously makes requests to Apple's availability api. When it finds some new stock near you, it displays the stores' name and distance from your zipcode then exits the program."
+  },
+  {
+    header: 'Synopsis',
+    content: [
+      { 
+        desc: 'Default arguments.',
+        example: '$ node index.js [bold]{--carrier} TMOBILE [bold]{--model} x [bold]{--color} gray [bold]{--storage} 256 [bold]{--delay} 30'
+      },
+      { 
+        desc: 'Simple example',
+        example: '$ node index.js [bold]{--zip} 10001 [bold]{--color} silver'
+      },
+      { 
+        desc: 'Help screen.',
+        example: '$ node index.js [bold]{--help}'
+      },
+    ]
+  },
+  {
+    header: "Options",
+    optionList: optionDefinitions
+  }
+]
+
+if (options['help'] || options['zip'] === undefined) {
+  console.log(getUsage(usageDefinition));
+  process.exit();
+}
 
 // Get part number for the specified device.
 const partNumber =

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,14 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
+    "ansi-escape-sequences": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "requires": {
+        "array-back": "2.0.0"
+      }
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -256,6 +264,17 @@
         "typical": "2.6.1"
       }
     },
+    "command-line-usage": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.1.tgz",
+      "integrity": "sha512-IqYzZuXizukrdhnbdUj2hh4iceycow+Jn10mER4lwU4IapYvl5ZzoRPsj5Yraew5oRk4yfFKMuULGvAfb5o29w==",
+      "requires": {
+        "ansi-escape-sequences": "4.0.0",
+        "array-back": "2.0.0",
+        "table-layout": "0.4.2",
+        "typical": "2.6.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -304,6 +323,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
+      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -961,6 +985,11 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1251,6 +1280,11 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -1456,6 +1490,18 @@
         "string-width": "2.1.1"
       }
     },
+    "table-layout": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
+      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "requires": {
+        "array-back": "2.0.0",
+        "deep-extend": "0.5.0",
+        "lodash.padend": "4.6.1",
+        "typical": "2.6.1",
+        "wordwrapjs": "3.0.0"
+      }
+    },
     "test-value": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
@@ -1552,6 +1598,15 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wordwrapjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "requires": {
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "command-line-args": "^4.0.7",
+    "command-line-usage": "^4.0.1",
     "node-fetch": "^1.7.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds descriptions to optionDefinitions, and adds a variable `usageDefinition` used to create the help screen using the npm package `command-line-usage`.   This screen appears from adding `--help` or omitting the `--zip` option, since it's required.